### PR TITLE
fix addPayload

### DIFF
--- a/src/JWTBuilder.php
+++ b/src/JWTBuilder.php
@@ -77,7 +77,7 @@ class JWTBuilder
   public function generate()
   {
     foreach ($this->payloads as $key => $val) {
-      $this->builder->with($key, $val);
+      $this->builder->set($key, $val);
     }
 
     $this->sign();


### PR DESCRIPTION
I tried to refresh tokens manually by set `expiry_in` field to 1 on `access_tokens` table. But keep getting error about undefined method `Lcobucci\JWT\Builder::with`. I inspect the code and seems the intention is to add payload to jwt token. 

This will fix that using `Lcobucci\JWT\Builder::set` to set claim. I tested the code and refreshing token worked. 