### PR TITLE
Refresh token improvement

### DIFF
--- a/src/Middleware/GluuTokenResponse.php
+++ b/src/Middleware/GluuTokenResponse.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace KWRI\LaravelGluuWrapper\Middleware;
+
+use Closure;
+use KWRI\LaravelGluuWrapper\Services\GluuAuth;
+
+class GluuTokenResponse
+{
+    protected $token;
+
+    /**
+     * @param GluuAuth $auth
+     */
+    public function __construct(GluuAuth $auth)
+    {
+        $this->auth = $auth;
+    }
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        $response = $next($request);
+
+        $token = $this->auth->setRequest($request)->parseTokenAsObject();
+
+        $response->header('Authorization', "Bearer " . $request->attributes->get('access_token'));
+
+        return $response;
+    }
+}

--- a/src/Services/GluuAuth.php
+++ b/src/Services/GluuAuth.php
@@ -3,6 +3,7 @@
 use Tymon\JWTAuth\JWTAuth;
 use Tymon\JWTAuth\Token;
 use Illuminate\Http\Request;
+use Tymon\JWTAuth\Exceptions\JWTException;
 
 class GluuAuth extends JWTAuth
 {


### PR DESCRIPTION
https://github.com/KWRI/core-package/issues/74

I spot some bug on refresh token. Current behaviour when refreshing token is to grab new token and save it to db. While old token still untouched. Client also don't know his token is updated. Which make client still make request using old token, therefore creating multiple record on `access_tokens` table.

This PR will update current token record when refreshing token. 

I also resend authorization header to client. This will be useful when token is refreshed, so client could update his token too.

To check this feature, you could set some token `expiry_in` field value in `access_tokens` table to 1. Try request with that token. The token should be updated on db and you'll get new token on response header.

Related PR: 
https://github.com/KWRI/core-package/pull/81
https://github.com/KWRI/contact-microservice/pull/93